### PR TITLE
add final project at genoa; begin employment at tinkergarten

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -45,7 +45,13 @@
         <hr noshade>
         <div class="section-header" id="experience">Experience</div>
         <div class="job-description">
-            <strong>Software Engineer,</strong> Genoa Telepsychiatry, New York, NY, 2017 - present<br>Building out a telepsychiatry web platform that allows patients in underserved mental health clinics to gain access to the care they need.
+            <strong>Senior Software Engineer,</strong> Tinkergarten, Brooklyn, NY, 2021 - present<br>Building a web portal for a community of early childhood education leaders and parents designed to get kids off screens and into the outdoors 🍃
+            <ul>
+                <li>
+                    Contributed major functionality to website redesign, including porting over payments.
+                </li>
+            </ul>
+            <strong>Software Engineer,</strong> Genoa Telepsychiatry, New York, NY, 2017 - 2021<br>Built out a telepsychiatry web platform that allows patients in underserved mental health clinics to gain access to the care they need.
             <ul>
                 <li>
                     Built full-stack, monolithic web application from the ground up to facilitate acquisition of data from new business.
@@ -58,6 +64,9 @@
                 </li>
                 <li>
                     Developed internal tools using microservices written in NodeJS to automate other teams' low-value work by tapping into their various data warehouses.
+                </li>
+                <li>
+                    Architected third-party data connector, creating shelf-ready web components that allowed for CRUD to seamlessly occur on our CRM.
                 </li>
             </ul>
             <strong>Computer Science Instructor,</strong> Girls Who Code, New York, NY, 2016<br>Taught core computer science concepts to an audience of high school girls full-time through the organization's Summer Immersion Program.


### PR DESCRIPTION
It's spring 2021. The end of the coronavirus pandemic is in sight, and thus begins the big thaw. Part of that's a new job. Got the offer while spooling up a solid project at the old gig. Woot.

The resume should reflect these changes.